### PR TITLE
change anaconda.org to AS instance in err msg

### DIFF
--- a/binstar_client/commands/login.py
+++ b/binstar_client/commands/login.py
@@ -7,6 +7,7 @@ import getpass
 import logging
 import socket
 import sys
+from urlparse import urlparse
 
 from binstar_client import errors
 from binstar_client.utils import get_config, get_binstar, store_token, \
@@ -26,7 +27,7 @@ def interactive_get_token(args, fail_if_already_exists=True):
     config = get_config(remote_site=args.site)
 
     url = config.get('url', 'https://api.anaconda.org')
-
+    parsed_url = urlparse(url)
     token = None
     hostname = getattr(args, 'hostname', platform.node())
     if getattr(args, 'login_username', None):
@@ -77,8 +78,13 @@ def interactive_get_token(args, fail_if_already_exists=True):
 
 
     if token is None:
-        msg = ('Sorry. Please try again '
-               '(go to https://anaconda.org/account/forgot_password '
+        if parsed_url.netloc.startswith('api.anaconda.org'):
+            netloc = 'anaconda.org'
+        else:
+            netloc = parsed_url.netloc
+        hostparts = (parsed_url.scheme, netloc)
+        msg = ('Sorry. Please try again ' +\
+               '(go to %s://%s/account/forgot_password ' % hostparts +\
                'to reset your password)')
         raise errors.BinstarError(msg)
 

--- a/binstar_client/commands/login.py
+++ b/binstar_client/commands/login.py
@@ -7,8 +7,10 @@ import getpass
 import logging
 import socket
 import sys
-from urlparse import urlparse
-
+try:
+    from urlparse import urlparse
+except ImportError:
+    from urllib.parse import urlparse
 from binstar_client import errors
 from binstar_client.utils import get_config, get_binstar, store_token, \
     bool_input


### PR DESCRIPTION
Fixes the error message that had anaconda.org hard-coded.  Refers to issue #205.