### PR TITLE
fix link to examples section on using tokens

### DIFF
--- a/binstar_client/commands/authorizations.py
+++ b/binstar_client/commands/authorizations.py
@@ -3,7 +3,7 @@ Manage Authentication tokens
 
 See also:
 
-  * [Using Binstar Tokens](http://docs.anaconda.org/examples.html#UsingBinstarTokens)
+  * [Using Anaconda.org Tokens](http://docs.anaconda.org/examples.html#UsingAnacondaOrgTokens)
 
 '''
 from __future__ import print_function


### PR DESCRIPTION
fix link to examples section on using tokens