### PR TITLE
Fix package upload using PyOpenSSL

### DIFF
--- a/binstar_client/requests_ext.py
+++ b/binstar_client/requests_ext.py
@@ -59,7 +59,7 @@ def encode_multipart_formdata_stream(fields, boundary=None):
         boundary = choose_boundary()
 
     for fieldname, value in iter_fields(fields):
-        body_write(b('--%s\r\n' % (boundary)))
+        body_write_encode('--%s\r\n' % (boundary))
 
         if isinstance(value, tuple):
             if len(value) == 3:
@@ -71,9 +71,9 @@ def encode_multipart_formdata_stream(fields, boundary=None):
                 if content_type is None:
                     content_type = 'application/octet-stream'
             body_write_encode('Content-Disposition: form-data; name="%s"; '
-                               'filename="%s"\r\n' % (fieldname, filename))
-            body_write(b('Content-Type: %s\r\n\r\n' %
-                       (content_type,)))
+                              'filename="%s"\r\n' % (fieldname, filename))
+            body_write_encode('Content-Type: %s\r\n\r\n' %
+                              (content_type,))
         else:
             data = value
             body_write_encode('Content-Disposition: form-data; name="%s"\r\n'
@@ -90,9 +90,9 @@ def encode_multipart_formdata_stream(fields, boundary=None):
 
         body_write(b'\r\n')
 
-    body_write(b('--%s--\r\n' % (boundary)))
+    body_write_encode('--%s--\r\n' % (boundary))
 
-    content_type = b('multipart/form-data; boundary=%s' % boundary)
+    content_type = 'multipart/form-data; boundary=%s' % (boundary)
 
     return body, content_type
 

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -17,7 +17,7 @@ requirements:
     - python
     - setuptools
     - clyent
-    - requests
+    - requests <2.8
     - pyyaml
     - dateutil
     - pytz

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 nbformat
 PyYAML
-requests
+requests<2.8
 python-dateutil
 pytz
 pillow

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     description='Anaconda.org command line client library',
     packages=find_packages(),
     install_requires=['clyent',
-                      'requests>=2.0',
+                      'requests>=2.0,<2.8',
                       'pyyaml',
                       'python-dateutil',
                       'pytz'],


### PR DESCRIPTION
Request body must only use bytes, rather than unicode objects.

Using `six.b` together with `unicode_literals` does not work correctly -
on Python 2.7, `six.b` is a pass-through (i.e. `lambda x: x`). If we are
using `unicode_literals`, then we should explicitly encode or use
`b'strings'` where appropriate.

Fixes #222, anaconda-server/anaconda-build#108