### PR TITLE
Possible fix for invalid token file

### DIFF
--- a/binstar_client/utils/__init__.py
+++ b/binstar_client/utils/__init__.py
@@ -138,7 +138,13 @@ def load_token(url):
     if isfile(tokenfile):
         log.debug("Found login token: {}".format(tokenfile))
         with open(tokenfile) as fd:
-            token = fd.read()
+            token = fd.read().strip()
+
+        if not token:
+            log.debug("Token file is empty: {}".format(tokenfile))
+            log.debug("Removing file: {}".format(tokenfile))
+            os.unlink(tokenfile)
+            token = None
     else:
         token = None
     return token


### PR DESCRIPTION
From the debug information from @drf5n in Anaconda-Server/docs.anaconda.org#145

```
[DEBUG] Found login token: /Users/drf/Library/Application Support/binstar/https%3A%2F%2Fapi.anaconda.org.token
[DEBUG] (u'This domain requires token authentication', 401)
```

The only way I could reproduce this error was to create an empty token file. For any other token value you should get `[DEBUG] (u'Invalid Token', 401)`

 This PR introduces a check that the token file is not empty and removes the file after that.

