### PR TITLE
Fix: no longer prompted to login on logout

### DIFF
--- a/binstar_client/commands/logout.py
+++ b/binstar_client/commands/logout.py
@@ -15,7 +15,11 @@ def main(args):
     if bs.token:
     # TODO: named 'application' because I was using the github model
     # Change it to name once we release the latest version of binstar server
-        bs.remove_authentication()
+        try:
+            bs.remove_authentication()
+        except errors.Unauthorized as err:
+            log.debug("The token that you are trying to remove may not be valid"
+                      "{}".format(err))
         remove_token(args)
         log.info("logout successful")
     else:


### PR DESCRIPTION
 * catch unauthorized error when performing logout.
 * don't prompt for interactive login when stdin is not a tty 