### PR TITLE
PR: Requests/PyOpenSSL version warning

### DIFF
--- a/binstar_client/commands/upload.py
+++ b/binstar_client/commands/upload.py
@@ -17,7 +17,7 @@ import os
 from os.path import exists
 import sys
 
-from binstar_client import errors
+from binstar_client import errors, requests_ext
 from binstar_client.utils import get_binstar, bool_input, upload_print_callback
 from binstar_client.utils.detect import detect_package_type, get_attrs
 
@@ -205,6 +205,12 @@ def main(args):
                 full_name = '%s/%s/%s/%s' % (username, package_name, version, file_attrs['basename'])
                 log.info('Distribution already exists. Please use the -i/--interactive or --force options or `anaconda remove %s`' % full_name)
                 raise
+            except requests_ext.OpenSslError:
+                requests_ext.warn_openssl()
+                if args.show_traceback != 'never':
+                    raise
+                else:
+                    raise errors.BinstarError('Could not upload package')
 
             uploaded_packages.append([package_name, upload_info])
             log.info("\n\nUpload(s) Complete\n")

--- a/binstar_client/requests_ext.py
+++ b/binstar_client/requests_ext.py
@@ -5,13 +5,19 @@ Created on Jun 6, 2013
 '''
 from __future__ import unicode_literals
 
+# Standard library imports
 from io import BytesIO, StringIO
+import codecs
+import logging
+
+# Third party imports
+import pkg_resources
 from requests.packages.urllib3.filepost import choose_boundary, iter_fields
 from requests.packages.urllib3.packages import six
-from requests.packages.urllib3.packages.six import b
-import codecs
+import requests
 
 encoder = codecs.lookup('utf-8')[0]
+log = logging.getLogger('binstar.requests_ext')
 
 def writer(lst):
     encoder()
@@ -158,3 +164,32 @@ def stream_multipart(data, files=None, callback=None):
     headers = {'Content-Type':content_type}
     return data, headers
 
+try:
+    import requests.packages.urllib3.contrib.pyopenssl
+    import OpenSSL.SSL
+except ImportError:
+    HAS_OPENSSL = False
+    OpenSslError = None
+else:
+    HAS_OPENSSL = True
+    OpenSslError = OpenSSL.SSL.Error
+
+requests_version = pkg_resources.parse_version(requests.__version__)
+
+# The first version that shipped urllib3 with issue shazow/urllib3#717
+min_requests_version = pkg_resources.parse_version('2.8')
+# TODO: add max_requests_version when requests ships with a fixed urllib3 to
+# limit warning to broken versions
+HAS_BROKEN_URLLIB3 = min_requests_version <= requests_version
+
+def warn_openssl():
+    '''
+    Output a warning about requests incompatibility
+    '''
+    if HAS_OPENSSL and HAS_BROKEN_URLLIB3:
+        log.error(
+            'The version of requests you are using is incompatible with '
+            'PyOpenSSL. Please downgrade requests to requests==2.7.0 or '
+            'uninstall PyOpenSSL.\n'
+            'See https://github.com/anaconda-server/anaconda-client/issues/222 '
+            'for more details.')

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -16,7 +16,7 @@ requirements:
     - python
     - setuptools
     - clyent
-    - requests <2.8
+    - requests
     - pyyaml
     - dateutil
     - pytz

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 nbformat
 PyYAML
-requests<2.8
+requests
 python-dateutil
 pytz
 pillow

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     description='Anaconda.org command line client library',
     packages=find_packages(),
     install_requires=['clyent',
-                      'requests>=2.0,<2.8',
+                      'requests>=2.0',
                       'pyyaml',
                       'python-dateutil',
                       'pytz'],


### PR DESCRIPTION
Removes restriction on requests version, generates a warning when a user tries to upload a package that triggers the bug.

I'm not sure if it should still show the whole traceback, since it's a known issue...  perhaps in case the OpenSSL error is not the one we are warning about?

Issue #256 