### PR TITLE
added fix to pass organization parameter if removing token from org

### DIFF
--- a/binstar_client/__init__.py
+++ b/binstar_client/__init__.py
@@ -118,12 +118,15 @@ class Binstar(OrgMixin, ChannelsMixin, PackageMixin):
         self._check_response(res)
         return res.json()
 
-    def remove_authentication(self, auth_name=None):
+    def remove_authentication(self, auth_name=None, organization=None):
         """
         Remove the current authentication or the one given by `auth_name`
         """
         if auth_name:
-            url = '%s/authentications/name/%s' % (self.domain, auth_name)
+            if organization:
+                url = '%s/authentications/org/%s/name/%s' % (self.domain, organization, auth_name)
+            else:
+                url = '%s/authentications/name/%s' % (self.domain, auth_name)
         else:
             url = '%s/authentications' % (self.domain,)
 

--- a/binstar_client/commands/authorizations.py
+++ b/binstar_client/commands/authorizations.py
@@ -129,7 +129,7 @@ def main(args):
         return
     elif args.remove:
         for auth_name in args.remove:
-            aserver_api.remove_authentication(auth_name)
+            aserver_api.remove_authentication(auth_name, args.organization)
             log.info("Removed token %s" % auth_name)
         return
     elif args.list_scopes:

--- a/binstar_client/tests/test_authorizations.py
+++ b/binstar_client/tests/test_authorizations.py
@@ -1,8 +1,3 @@
-'''
-Created on Feb 18, 2014
-
-@author: sean
-'''
 from __future__ import unicode_literals
 from binstar_client.scripts.cli import main
 from binstar_client.tests.fixture import CLITestCase

--- a/binstar_client/tests/test_authorizations.py
+++ b/binstar_client/tests/test_authorizations.py
@@ -1,0 +1,59 @@
+'''
+Created on Feb 18, 2014
+
+@author: sean
+'''
+from __future__ import unicode_literals
+from binstar_client.scripts.cli import main
+from binstar_client.tests.fixture import CLITestCase
+from binstar_client.tests.urlmock import urlpatch
+from binstar_client.errors import BinstarError
+import unittest
+from mock import patch
+
+
+class Test(CLITestCase):
+    @urlpatch
+    def test_remove_token_from_org(self, urls):
+        remove_token = urls.register(
+            method='DELETE',
+            path='/authentications/org/orgname/name/tokenname',
+            content='{"token": "a-token"}',
+            status=201
+        )
+        main(['--show-traceback', 'auth', '--remove', 'tokenname', '-o', 'orgname'], False)
+        self.assertIn('Removed token tokenname', self.stream.getvalue())
+
+        remove_token.assertCalled()
+
+    @urlpatch
+    def test_remove_token(self, urls):
+        remove_token = urls.register(
+            method='DELETE',
+            path='/authentications/name/tokenname',
+            content='{"token": "a-token"}',
+            status=201
+        )
+        main(['--show-traceback', 'auth', '--remove', 'tokenname'], False)
+        self.assertIn('Removed token tokenname', self.stream.getvalue())
+
+        remove_token.assertCalled()
+
+
+    @urlpatch
+    def test_remove_token_forbidden(self, urls):
+        remove_token = urls.register(
+            method='DELETE',
+            path='/authentications/org/wrong_org/name/tokenname',
+            content='{"token": "a-token"}',
+            status=403
+        )
+        with self.assertRaises(BinstarError):
+            main(['--show-traceback', 'auth', '--remove', 'tokenname', '-o', 'wrong_org'], False)
+        self.assertEqual('', self.stream.getvalue())
+
+        remove_token.assertCalled()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Related #224 

allows `anaconda auth` to pass the `-o` parameter to the server.

example:

`anaconda auth -r TestToken -o mytestorg`