### PR TITLE
add unused *args, **kwargs to file handler

### DIFF
--- a/binstar_client/tests/test_upload.py
+++ b/binstar_client/tests/test_upload.py
@@ -79,7 +79,26 @@ class Test(CLITestCase):
 
         registry.assertAllCalled()
 
+    @urlpatch
+    def test_upload_file(self, registry):
+        registry.register(method='GET', path='/user', content='{"login": "eggs"}')
+        registry.register(method='GET', path='/package/eggs/test-package34', content='{}')
+        registry.register(method='GET', path='/release/eggs/test-package34/0.3.1', content='{}')
+        registry.register(method='GET', path='/dist/eggs/test-package34/0.3.1/test_package34-0.3.1.tar.gz', status=404, content='{}')
 
+        content = {"post_url": "http://s3_url.com/s3_url", "form_data": {}, "dist_id": "dist_id"}
+        registry.register(method='POST', path='/stage/eggs/test-package34/0.3.1/test_package34-0.3.1.tar.gz', content=content)
+
+        registry.register(method='POST', path='/s3_url', status=201)
+        registry.register(method='POST', path='/commit/eggs/test-package34/0.3.1/test_package34-0.3.1.tar.gz', status=200, content={})
+
+        main(['--show-traceback', 'upload',
+              '--package-type', 'file',
+              '--package', 'test-package34',
+              '--version', '0.3.1',
+              self.data_dir('test_package34-0.3.1.tar.gz')], False)
+
+        registry.assertAllCalled()
 
 if __name__ == '__main__':
     unittest.main()

--- a/binstar_client/utils/detect.py
+++ b/binstar_client/utils/detect.py
@@ -17,12 +17,17 @@ log = logging.getLogger('binstar.detect')
 #===============================================================================
 #
 #===============================================================================
+
+def file_handler(filename, fileobj, *args, **kwargs):
+    return ({}, {'description': ''},
+            {'basename': path.basename(filename), 'attrs':{}})
+
 detectors = {'conda':inspect_conda_package,
              'pypi': inspect_pypi_package,
              'r': inspect_r_package,
              'ipynb': inspect_ipynb_package,
              conda_installer.PACKAGE_TYPE: conda_installer.inspect_package,
-             'file': lambda filename, fileobj: ({}, {'description': ''}, {'basename': path.basename(filename), 'attrs':{}}),
+             'file': file_handler,
              }
 
 


### PR DESCRIPTION
This fixes the error reported by Jasmine Sandhu in flowdock Tuesday, January 5:

```
 > anaconda -V
anaconda Command line client (version 1.2.1)

> anaconda upload -t file bz-test-data.tgz 
Using Anaconda Cloud api site https://api.anaconda.org
extracting package attributes for upload ...
[ERROR] 
Traceback (most recent call last):
  File "/Users/jsandhu/miniconda/bin/anaconda", line 6, in <module>
    sys.exit(main())
  File "/Users/jsandhu/miniconda/lib/python2.7/site-packages/binstar_client/scripts/cli.py", line 87, in main
    description=__doc__, version=version)
  File "/Users/jsandhu/miniconda/lib/python2.7/site-packages/binstar_client/scripts/cli.py", line 66, in binstar_main
    return args.main(args)
  File "/Users/jsandhu/miniconda/lib/python2.7/site-packages/binstar_client/commands/upload.py", line 170, in main
    filename, parser_args=args)
  File "/Users/jsandhu/miniconda/lib/python2.7/site-packages/binstar_client/utils/detect.py", line 96, in get_attrs
    return detectors[package_type](filename, fileobj, *args, **kwargs)
TypeError: <lambda>() got an unexpected keyword argument 'parser_args'
```

I will add a test of the new behavior.