### PR TITLE
Fix `channel --remove` command

### DIFF
--- a/binstar_client/mixins/channels.py
+++ b/binstar_client/mixins/channels.py
@@ -57,7 +57,7 @@ class ChannelsMixin(object):
         :param filename: The exact file to remove the channel from
         
         '''
-        url = '%s/channels/%s/%s' % (self.domain, channel, owner)
+        url = '%s/channels/%s/%s' % (self.domain, owner, channel)
         data, headers = jencode(package=package, version=version, basename=filename)
 
         res = self.session.delete(url, data=data, headers=headers)


### PR DESCRIPTION
Issue #204 

Order of the arguments was incorrect in the URL generation.