### PR TITLE
'authenticated' -> 'authorized and authenticated'

### DIFF
--- a/binstar_client/commands/package.py
+++ b/binstar_client/commands/package.py
@@ -56,6 +56,6 @@ def add_parser(subparsers):
                              'This package will be available only on your personal registries'))
     group.add_argument('--private', action='store_const', const='private', dest='access',
                        help=('Set the package access to private '
-                             'This package will require authenticated access to install'))
+                             'This package will require authorized and authenticated access to install'))
 
     parser.set_defaults(main=main)


### PR DESCRIPTION
Clarify that installing a private package requires authorized as well as authenticated access per discussion in https://github.com/Anaconda-Server/support/issues/19#event-531670734 .