### PR TITLE
PR: Include optional args for packages api

### DIFF
--- a/binstar_client/__init__.py
+++ b/binstar_client/__init__.py
@@ -180,18 +180,34 @@ class Binstar(OrgMixin, ChannelsMixin, PackageMixin):
 
         return res.json()
 
-    def user_packages(self, login=None):
+    def user_packages(self, login=None, platform=None, package_type=None,
+                      type_=None):
         '''
-        Returns a list of packages for a given user
+        Returns a list of packages for a given user and optionally filter
+        by `platform`, `package_type` and `type_`.
 
-        :param login: (optional) the login name of the user or None. If login is None
-                      this method will return the packages for the authenticated user.
+        :param login: (optional) the login name of the user or None. If login
+                      is None this method will return the packages for the
+                      authenticated user.
 
         '''
         if login:
-            url = '%s/packages/%s' % (self.domain, login)
+            url = '{0}/packages/{1}'.format(self.domain, login)
         else:
-            url = '%s/packages' % (self.domain)
+            url = '{0}/packages'.format(self.domain)
+
+        arguments = []
+        if platform:
+            arguments.append('platform={0}'.format(platform))
+
+        if package_type:
+            arguments.append('package_type={0}'.format(package_type))
+
+        if type_:
+            arguments.append('type={0}'.format(type_))
+
+        if platform or package_type or type_:
+            url = "{0}?{1}".format(url, '&'.join(arguments))
 
         res = self.session.get(url)
         self._check_response(res)

--- a/binstar_client/__init__.py
+++ b/binstar_client/__init__.py
@@ -1,5 +1,6 @@
 from __future__ import unicode_literals
 import base64
+import collections
 import json
 import os
 import requests
@@ -239,7 +240,7 @@ class Binstar(OrgMixin, ChannelsMixin, PackageMixin):
         else:
             url = '{0}/packages'.format(self.domain)
 
-        arguments = {}
+        arguments = collections.OrderedDict()
 
         if platform:
             arguments['platform'] = platform

--- a/binstar_client/__init__.py
+++ b/binstar_client/__init__.py
@@ -23,8 +23,10 @@ import platform
 log = logging.getLogger('binstar')
 
 from ._version import get_versions
+
 __version__ = get_versions()['version']
 del get_versions
+
 
 class Binstar(OrgMixin, ChannelsMixin, PackageMixin):
     '''
@@ -180,8 +182,13 @@ class Binstar(OrgMixin, ChannelsMixin, PackageMixin):
 
         return res.json()
 
-    def user_packages(self, login=None, platform=None, package_type=None,
-                      type_=None):
+    def user_packages(
+            self,
+            login=None,
+            platform=None,
+            package_type=None,
+            type_=None,
+            access=None):
         '''
         Returns a list of packages for a given user and optionally filter
         by `platform`, `package_type` and `type_`.
@@ -189,27 +196,32 @@ class Binstar(OrgMixin, ChannelsMixin, PackageMixin):
         :param login: (optional) the login name of the user or None. If login
                       is None this method will return the packages for the
                       authenticated user.
-
+        :param platform: only find packages that include files for this platform.
+           (e.g. 'linux-64', 'osx-64', 'win-32')
+        :param package_type: only find packages that have this kind of file
+           (e.g. 'env', 'conda', 'pypi')
+        :param type_: only find packages that have this conda `type`
+           (i.e. 'app')
+        :param access: only find packages that have this access level
+           (e.g. 'private', 'authenticated', 'public')
         '''
         if login:
             url = '{0}/packages/{1}'.format(self.domain, login)
         else:
             url = '{0}/packages'.format(self.domain)
 
-        arguments = []
+        arguments = {}
+
         if platform:
-            arguments.append('platform={0}'.format(platform))
-
+            arguments['platform'] = platform
         if package_type:
-            arguments.append('package_type={0}'.format(package_type))
-
+            arguments['package_type'] = package_type
         if type_:
-            arguments.append('type={0}'.format(type_))
+            arguments['type'] = type_
+        if access:
+            arguments['access'] = access
 
-        if platform or package_type or type_:
-            url = "{0}?{1}".format(url, '&'.join(arguments))
-
-        res = self.session.get(url)
+        res = self.session.get(url, params=arguments)
         self._check_response(res)
 
         return res.json()

--- a/binstar_client/tests/test_packages.py
+++ b/binstar_client/tests/test_packages.py
@@ -1,0 +1,38 @@
+import unittest
+
+from binstar_client.tests.urlmock import urlpatch
+from binstar_client import Binstar
+
+
+class Test(unittest.TestCase):
+    @urlpatch
+    def test_packages_array_param(self, urls):
+        api = Binstar()
+        urls.register(method='GET', path='/packages/u1?package_type=conda&package_type=pypi', content='[]')
+
+        packages = api.user_packages('u1', package_type=['conda', 'pypi'])
+
+        urls.assertAllCalled()
+
+    @urlpatch
+    def test_packages_parameters(self, urls):
+        api = Binstar()
+        urls.register(method='GET', path='/packages/u1?platform=osx-64&package_type=conda&type=app', content='[]')
+
+        packages = api.user_packages('u1', platform='osx-64', type_='app', package_type='conda')
+
+        urls.assertAllCalled()
+
+    @urlpatch
+    def test_packages_empty(self, urls):
+        api = Binstar()
+        urls.register(method='GET', path='/packages/u1', content='[]')
+
+        packages = api.user_packages('u1')
+
+        self.assertEqual(packages, [])
+        urls.assertAllCalled()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Related to https://github.com/Anaconda-Server/anaconda-server/pull/1662

# Description

I added some extra checks to get arguments via GET and refine the query based on `package_type`, `platform` and `type`, so I can query something like

**api.anaconda.org/packages/goanpeca?platform=linux-64&package_type=conda&type=app**

and receive something like:

```json
[
  {
    "conda_platforms": [
      "None-None"
    ], 
    "app_type": {
      "v0.1.0b1": "desk"
    }, 
    "name": "conda-manager", 
    "versions": [
      "v0.1.0b1"
    ], 
    "url": "http://api.None/packages/goanpeca/conda-manager", 
    "app_entry": {
      "v0.1.0b1": "conda-manager"
    }, 
    "package_types": [
      "conda"
    ], 
    "html_url": "http://None/goanpeca/conda-manager", 
    "latest_version": "v0.1.0b1", 
    "summary": "Graphical conda package manager with Spyder plugin integration", 
    "public": true, 
    "full_name": "goanpeca/conda-manager", 
    "app_summary": {
      "v0.1.0b1": "awesome"
    }, 
    "owner": "goanpeca", 
    "id": "56bac9cceff8a15384ba642e", 
    "revision": 4
  }
]
```

@srossross I am doing this the right way?