### PR TITLE
reduce memory usage and improve speed by using streaming tar operations.

### DIFF
--- a/binstar_client/inspect_package/conda.py
+++ b/binstar_client/inspect_package/conda.py
@@ -75,15 +75,18 @@ def get_subdir(index):
 
 def inspect_conda_package(filename, fileobj, *args, **kwargs):
 
-    tar = tarfile.open(filename, fileobj=fileobj)
-    index = tar.extractfile('info/index.json')
-    index = json.loads(index.read().decode())
-
-    try:
-        recipe = tar.extractfile('info/recipe.json')
-        recipe = json.loads(recipe.read().decode())
-    except KeyError:
-        recipe = {}
+    tar = tarfile.open(filename, fileobj=fileobj, mode="r|bz2")
+    recipe = {}
+    for info in tar:
+        if info.name == 'info/index.json':
+            index = tar.extractfile(info)
+            index = json.loads(index.read().decode())
+        elif info.name == 'info/recipe.json':
+            try:
+                recipe = tar.extractfile(info)
+                recipe = json.loads(recipe.read().decode())
+            except KeyError:
+                recipe = {}
 
     about = recipe.pop('about', {})
 

--- a/binstar_client/utils/detect.py
+++ b/binstar_client/utils/detect.py
@@ -42,8 +42,12 @@ def is_conda(filename):
     log.debug("Testing if conda package ..")
     if filename.endswith('.tar.bz2'):  # Could be a conda package
         try:
-            with tarfile.open(filename) as tf:
-                tf.getmember('info/index.json')
+            with tarfile.open(filename, mode="r|bz2") as tf:
+                for info in tf:
+                    if info.name == "info/index.json":
+                        break
+                else:
+                    raise KeyError
         except KeyError:
             log.debug("Not conda  package no 'info/index.json' file in the tarball")
             return False


### PR DESCRIPTION
I've been testing using conda for managing data dependencies (not just software deps). 
When the tar.bz2 files get large, the memory use and speed are intolerable. This makes minor changes to use the streaming tar stuff.
On my test case of a 780MB tar.bz2, it:
+ prevents a MemoryError on my laptop with 8GB of RAM (memory use after this PR is not noticeable)
+ takes the time to `determine_package_type` from 2 minutes to 0.05 seconds.
+ also speeds up extracting package attributes.

I'd like to make another PR to conda-build so that items are added to the tar file by order of size since likely we'll want to access the recipe.json and index.json frequently and quickly without incurring the penalty of decompressing all members of the tar file--with the idea that these JSON files will be the smallest and the software or data will be at the end of the file.