### PR TITLE
OpenSSL issue with requests is fixed in 2.9.1, stop warning

### DIFF
--- a/binstar_client/requests_ext.py
+++ b/binstar_client/requests_ext.py
@@ -178,9 +178,9 @@ requests_version = pkg_resources.parse_version(requests.__version__)
 
 # The first version that shipped urllib3 with issue shazow/urllib3#717
 min_requests_version = pkg_resources.parse_version('2.8')
-# TODO: add max_requests_version when requests ships with a fixed urllib3 to
+max_requests_version = pkg_resources.parse_version('2.9.1')
 # limit warning to broken versions
-HAS_BROKEN_URLLIB3 = min_requests_version <= requests_version
+HAS_BROKEN_URLLIB3 = min_requests_version <= requests_version < max_requests_version
 
 def warn_openssl():
     '''
@@ -189,7 +189,7 @@ def warn_openssl():
     if HAS_OPENSSL and HAS_BROKEN_URLLIB3:
         log.error(
             'The version of requests you are using is incompatible with '
-            'PyOpenSSL. Please downgrade requests to requests==2.7.0 or '
+            'PyOpenSSL. Please upgrade requests to requests>=2.9.1 or '
             'uninstall PyOpenSSL.\n'
             'See https://github.com/anaconda-server/anaconda-client/issues/222 '
             'for more details.')


### PR DESCRIPTION
See #256 
We should not issue this warning if they're using a newer version of requests.