### PR TITLE
Fix/netrc auth

### DIFF
--- a/binstar_client/__init__.py
+++ b/binstar_client/__init__.py
@@ -8,7 +8,7 @@ import warnings
 # For backwards compatibility
 from .errors import *
 from . import errors
-from .requests_ext import stream_multipart
+from .requests_ext import stream_multipart, NullAuth
 
 from .utils import compute_hash, jencode, pv
 from .utils.http_codes import STATUS_CODES
@@ -39,6 +39,7 @@ class Binstar(OrgMixin, ChannelsMixin, PackageMixin):
         self._session = requests.Session()
         self._session.headers['x-binstar-api-version'] = __version__
         self.session.verify = verify
+        self.session.auth = NullAuth()
         self.token = token
 
         user_agent = 'Anaconda-Client/{} (+https://anaconda.org)'.format(__version__)

--- a/binstar_client/inspect_package/tests/test_ipynb.py
+++ b/binstar_client/inspect_package/tests/test_ipynb.py
@@ -1,7 +1,7 @@
 from os import path
 import unittest
 
-from ..ipynb import IPythonNotebook, inspect_ipynb_package
+from binstar_client.inspect_package.ipynb import IPythonNotebook, inspect_ipynb_package
 
 
 def data_path(filename):

--- a/binstar_client/requests_ext.py
+++ b/binstar_client/requests_ext.py
@@ -193,3 +193,22 @@ def warn_openssl():
             'uninstall PyOpenSSL.\n'
             'See https://github.com/anaconda-server/anaconda-client/issues/222 '
             'for more details.')
+
+
+class NullAuth(requests.auth.AuthBase):
+    '''force requests to ignore the ``.netrc``
+
+    Some sites do not support regular authentication, but we still
+    want to store credentials in the ``.netrc`` file and submit them
+    as form elements. Without this, requests would otherwise use the
+    .netrc which leads, on some sites, to a 401 error.
+
+    https://github.com/kennethreitz/requests/issues/2773
+
+    Use with::
+
+        requests.get(url, auth=NullAuth())
+    '''
+
+    def __call__(self, r):
+        return r

--- a/binstar_client/tests/data/netrc
+++ b/binstar_client/tests/data/netrc
@@ -1,0 +1,1 @@
+default login anonymous password pass

--- a/binstar_client/tests/test_whoami.py
+++ b/binstar_client/tests/test_whoami.py
@@ -4,6 +4,8 @@ Created on Feb 18, 2014
 @author: sean
 '''
 from __future__ import unicode_literals
+
+import os
 import unittest
 import mock
 from binstar_client.scripts.cli import main
@@ -42,6 +44,8 @@ class Test(CLITestCase):
     def test_netrc_ignored(self, urls, expanduser):
         # Disable token authentication
         self.load_token.return_value = None
+        os.environ.pop('BINSTAR_API_TOKEN', None)
+        os.environ.pop('ANACONDA_API_TOKEN', None)
 
         # requests.get_netrc_auth uses expanduser to find the netrc file, point to our
         # test file

--- a/binstar_client/tests/test_whoami.py
+++ b/binstar_client/tests/test_whoami.py
@@ -10,6 +10,7 @@ from binstar_client.scripts.cli import main
 from binstar_client.tests.fixture import CLITestCase
 from binstar_client.tests.urlmock import urlpatch
 import json
+import requests.utils
 
 
 class Test(CLITestCase):
@@ -34,8 +35,24 @@ class Test(CLITestCase):
         main(['--show-traceback', 'whoami'], False)
         self.assertIn('eggs', self.stream.getvalue()) 
 
-        user.assertCalled() 
-        
+        user.assertCalled()
+
+    @urlpatch
+    @mock.patch('os.path.expanduser')
+    def test_netrc_ignored(self, urls, expanduser):
+        # Disable token authentication
+        self.load_token.return_value = None
+
+        # requests.get_netrc_auth uses expanduser to find the netrc file, point to our
+        # test file
+        expanduser.return_value = self.data_dir('netrc')
+        auth = requests.utils.get_netrc_auth('http://localhost', raise_errors=True)
+        self.assertEqual(auth, ('anonymous', 'pass'))
+
+        user = urls.register(path='/user', status=401)
+
+        main(['--show-traceback', 'whoami'], False)
+        self.assertNotIn('Authorization', user.req.headers)
         
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Issue #296 

Prevent .netrc authentication from taking place. It's just not expected by users.

cc @bkreider 

I think the same change will need to happen in conda, otherwise this error will still occur when performing  `conda install`.