### PR TITLE
Upload notebooks with thumbnails

### DIFF
--- a/binstar_client/commands/download.py
+++ b/binstar_client/commands/download.py
@@ -1,7 +1,7 @@
 '''
 Usage:
-    anaconda notebook download notebook
-    anaconda notebook download user/notebook
+    anaconda download notebook
+    anaconda download user/notebook
 '''
 
 from __future__ import unicode_literals

--- a/binstar_client/commands/notebook.py
+++ b/binstar_client/commands/notebook.py
@@ -1,9 +1,7 @@
 """
-Usage:
-
-    anaconda notebook upload notebook.ipynb
-    anaconda notebook download notebook
-    anaconda notebook download user/notebook
+[Deprecation warning]
+`anaconda notebook` is going to be deprecated
+use `anaconda upload/download` instead
 """
 
 from __future__ import unicode_literals
@@ -32,8 +30,9 @@ def add_parser(subparsers):
 def add_upload_parser(subparsers):
     description = "Upload a notebook to anaconda.org"
     epilog = """
-    Usage:
-        anaconda notebook upload notebook.ipynb
+    [Deprecation warning]
+    `anaconda notebook` is going to be deprecated
+    use `anaconda upload` instead
     """
     parser = subparsers.add_parser('upload',
                                    formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -70,9 +69,9 @@ def add_upload_parser(subparsers):
 def add_download_parser(subparsers):
     description = "Download notebooks from anaconda.org"
     epilog = """
-    Usage:
-        anaconda notebook download notebook
-        anaconda notebook download user/notebook
+    [Deprecation warning]
+    `anaconda notebook` is going to be deprecated
+    use `anaconda download` instead
     """
     parser = subparsers.add_parser('download',
                                    formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -109,6 +108,8 @@ def upload(args):
 
     try:
         upload_info = uploader.upload(force=args.force)
+        log.warn("`anaconda notebook` is going to be deprecated")
+        log.warn("use `anaconda upload` instead.")
         log.info("{} has been uploaded.".format(args.notebook))
         log.info("You can visit your notebook at {}".format(notebook_url(upload_info)))
     except (errors.BinstarError, IOError) as e:
@@ -123,6 +124,8 @@ def download(args):
     downloader = Downloader(aserver_api, username, notebook)
     try:
         download_info = downloader(output=args.output, force=args.force)
+        log.warn("`anaconda notebook` is going to be deprecated")
+        log.warn("use `anaconda download` instead.")
         log.info("{} has been downloaded as {}.".format(args.handle, download_info[0]))
         if has_environment(download_info[0]):
             log.info("{} has an environment embedded.".format(download_info[0]))

--- a/binstar_client/commands/upload.py
+++ b/binstar_client/commands/upload.py
@@ -113,8 +113,14 @@ def add_package(aserver_api, args, username, package_name, package_attrs, packag
                     raise errors.BinstarError("Could not detect package summary for package type %s, please use the --summary option" % (package_type,))
                 summary = package_attrs['summary']
 
-            aserver_api.add_package(username, package_name, summary, package_attrs.get('license'),
-                                public=True)
+            aserver_api.add_package(
+                username,
+                package_name,
+                summary,
+                package_attrs.get('license'),
+                public=True,
+                attrs=package_attrs
+            )
 
 
 def add_release(aserver_api, args, username, package_name, version, release_attrs):

--- a/binstar_client/commands/upload.py
+++ b/binstar_client/commands/upload.py
@@ -1,6 +1,7 @@
 '''
 
     anaconda upload CONDA_PACKAGE_1.bz2
+    anaconda upload notebook.ipynb
 
 ##### See Also
 


### PR DESCRIPTION
Deprecate
`anaconda notebook upload`

Invite people to use:
`anaconda upload notebook.ipynb`

#295