### PR TITLE
Fix --from-label, --to-label arguments to anaconda copy

### DIFF
--- a/binstar_client/commands/copy.py
+++ b/binstar_client/commands/copy.py
@@ -50,8 +50,8 @@ def add_parser(subparsers):
     _from = parser.add_mutually_exclusive_group()
     _to = parser.add_mutually_exclusive_group()
 
-    _from.add_argument('--from-channel', help='[DEPRECATED]Channel to copy packages from', default='main')
-    parser.add_argument('--to-channel', help='[DEPRECATED]Channel to put all packages into', default='main')
+    _from.add_argument('--from-channel', help='[DEPRECATED]Channel to copy packages from')
+    _to.add_argument('--to-channel', help='[DEPRECATED]Channel to put all packages into')
 
     _from.add_argument('--from-label', help='Label to copy packages from', default='main')
     _to.add_argument('--to-label', help='Label to put all packages into', default='main')


### PR DESCRIPTION
Fixes #280 

@malev 