### PR TITLE
break when all data from tarball is found

### DIFF
--- a/binstar_client/inspect_package/conda.py
+++ b/binstar_client/inspect_package/conda.py
@@ -75,7 +75,7 @@ def get_subdir(index):
 
 def inspect_conda_package(filename, fileobj, *args, **kwargs):
 
-    index, recipe = None, None
+    index, recipe = None, {}
 
     with tarfile.open(filename, fileobj=fileobj, mode="r|bz2") as tar:
         for info in tar:
@@ -83,13 +83,13 @@ def inspect_conda_package(filename, fileobj, *args, **kwargs):
                 index = tar.extractfile(info)
                 index = json.loads(index.read().decode())
             elif info.name == 'info/recipe.json':
-                try:
-                    recipe = tar.extractfile(info)
-                    recipe = json.loads(recipe.read().decode())
-                except KeyError:
-                    recipe = None
-            if index is not None and recipe is not None:
+                recipe = tar.extractfile(info)
+                recipe = json.loads(recipe.read().decode())
+            if index is not None and recipe != {}:
                 break
+        else:
+            if index is None:
+                raise TypeError("info/index.json required in conda package")
 
     about = recipe.pop('about', {})
 

--- a/binstar_client/inspect_package/conda.py
+++ b/binstar_client/inspect_package/conda.py
@@ -76,7 +76,7 @@ def get_subdir(index):
 def inspect_conda_package(filename, fileobj, *args, **kwargs):
 
     tar = tarfile.open(filename, fileobj=fileobj, mode="r|bz2")
-    recipe = {}
+    index, recipe = None, None
     for info in tar:
         if info.name == 'info/index.json':
             index = tar.extractfile(info)
@@ -86,7 +86,9 @@ def inspect_conda_package(filename, fileobj, *args, **kwargs):
                 recipe = tar.extractfile(info)
                 recipe = json.loads(recipe.read().decode())
             except KeyError:
-                recipe = {}
+                recipe = None
+        if index is not None and recipe is not None:
+            break
 
     about = recipe.pop('about', {})
 

--- a/binstar_client/inspect_package/conda.py
+++ b/binstar_client/inspect_package/conda.py
@@ -75,20 +75,21 @@ def get_subdir(index):
 
 def inspect_conda_package(filename, fileobj, *args, **kwargs):
 
-    tar = tarfile.open(filename, fileobj=fileobj, mode="r|bz2")
     index, recipe = None, None
-    for info in tar:
-        if info.name == 'info/index.json':
-            index = tar.extractfile(info)
-            index = json.loads(index.read().decode())
-        elif info.name == 'info/recipe.json':
-            try:
-                recipe = tar.extractfile(info)
-                recipe = json.loads(recipe.read().decode())
-            except KeyError:
-                recipe = None
-        if index is not None and recipe is not None:
-            break
+
+    with tarfile.open(filename, fileobj=fileobj, mode="r|bz2") as tar:
+        for info in tar:
+            if info.name == 'info/index.json':
+                index = tar.extractfile(info)
+                index = json.loads(index.read().decode())
+            elif info.name == 'info/recipe.json':
+                try:
+                    recipe = tar.extractfile(info)
+                    recipe = json.loads(recipe.read().decode())
+                except KeyError:
+                    recipe = None
+            if index is not None and recipe is not None:
+                break
 
     about = recipe.pop('about', {})
 


### PR DESCRIPTION
This is the missing piece from #d299e183 that actually allows the command to break once it has found the info it needs. This prevents looping over all parts of the tar ball.