### PR TITLE
Ref/specs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG:
 
+## Unreleased
+### Fixed
+* `anaconda groups` subcommand had several bugs, and was difficult to use (#312)
+
 ## 1.4.0 (2016-03-24)
 
   * `BinstarClient.user_packages` learned arguments `platform`, `package_type`,

--- a/binstar_client/commands/groups.py
+++ b/binstar_client/commands/groups.py
@@ -8,67 +8,41 @@ from pprint import pprint
 import re
 from binstar_client.pprintb import package_list, user_list
 
-def group_spec(spec):
-    '''
-    Spec
-    '''
-    pat = re.compile('^(?P<org>[a-z][a-z0-9_-]+)(/:(?P<group_name>[a-z][a-z0-9_-]+)(/(?P<member>[a-z][a-z0-9_-]+))?)?$')
-    mat = pat.match(spec)
-    if mat is None:
-        raise ArgumentError('dfasdf')
+from binstar_client.utils.spec import group_spec
 
-    return mat.groupdict()
+
 
 def main(args):
 
     aserver_api = get_server_api(args.token, args.site, args.log_level)
+    spec = args.spec
+    action = args.action
 
-    if args.action == 'add':
-        result = aserver_api.add_group(args.spec['org'], args.spec['group_name'], args.perms)
+    if action == 'add':
+        result = aserver_api.add_group(spec.org, spec.group_name, args.perms)
         pprint(result)
-    elif args.action == 'show':
-        if args.spec['group_name']:
-            result = aserver_api.group(args.spec['org'], args.spec['group_name'])
+    elif action == 'show':
+        if spec.group_name:
+            result = aserver_api.group(spec.org, spec.group_name)
             pprint(result)
         else:
-            result = aserver_api.groups(args.spec['org'])
+            result = aserver_api.groups(spec.org)
             pprint(result)
 
-    elif args.action == 'members':
-        if not args.spec['group_name']:
-            raise ArgumentError('must specify group_name in spec')
-        result = aserver_api.group_members(args.spec['org'], args.spec['group_name'])
+    elif action == 'members':
+        result = aserver_api.group_members(spec.org, spec.group_name)
         user_list(result, args.verbose)
-    elif args.action == 'add_member':
-        if not args.spec['group_name']:
-            raise ArgumentError('must specify group_name in spec')
-        if not args.spec['member']:
-            raise ArgumentError('must specify group_name in spec')
-        aserver_api.add_group_member(args.spec['org'], args.spec['group_name'], args.spec['member'])
-    elif args.action == 'remove_member':
-        if not args.spec['group_name']:
-            raise ArgumentError('must specify group_name in spec')
-        if not args.spec['member']:
-            raise ArgumentError('must specify group_name in spec')
-        aserver_api.remove_group_member(args.spec['org'], args.spec['group_name'], args.spec['member'])
-    elif args.action == 'packages':
-        if not args.spec['group_name']:
-            raise ArgumentError('must specify group_name in spec')
-        result = aserver_api.group_packages(args.spec['org'], args.spec['group_name'])
+    elif action == 'add_member':
+        aserver_api.add_group_member(spec.org, spec.group_name, spec.member)
+    elif action == 'remove_member':
+        aserver_api.remove_group_member(spec.org, spec.group_name, spec.member)
+    elif action == 'packages':
+        result = aserver_api.group_packages(spec.org, spec.group_name)
         package_list(result, args.verbose)
-
-    elif args.action == 'add_package':
-        if not args.spec['group_name']:
-            raise ArgumentError('must specify group_name in spec')
-        if not args.spec['member']:
-            raise ArgumentError('must specify group_name in spec')
-        aserver_api.add_group_package(args.spec['org'], args.spec['group_name'], args.spec['member'])
-    elif args.action == 'remove_package':
-        if not args.spec['group_name']:
-            raise ArgumentError('must specify group_name in spec')
-        if not args.spec['member']:
-            raise ArgumentError('must specify group_name in spec')
-        aserver_api.remove_group_package(args.spec['org'], args.spec['group_name'], args.spec['member'])
+    elif action == 'add_package':
+        aserver_api.add_group_package(spec.org, spec.group_name, spec.member)
+    elif action == 'remove_package':
+        aserver_api.remove_group_package(spec.org, spec.group_name, spec.member)
     else:
         raise NotImplementedError(args.action)
 

--- a/binstar_client/commands/groups.py
+++ b/binstar_client/commands/groups.py
@@ -18,12 +18,13 @@ def main(args):
     aserver_api = get_server_api(args.token, args.site, args.log_level)
     spec = args.spec
     action = args.action
+    verbose = args.log_level == logging.DEBUG
 
     if action == 'add':
-        result = aserver_api.add_group(spec.org, spec.group_name, args.perms)
-        pprint(result)
+        aserver_api.add_group(spec.org, spec.group_name, args.perms)
+        print('Created the group %s' % (spec,))
     elif action == 'show':
-        if spec.group_name:
+        if spec._group_name:
             result = aserver_api.group(spec.org, spec.group_name)
             pprint(result)
         else:
@@ -32,18 +33,22 @@ def main(args):
 
     elif action == 'members':
         result = aserver_api.group_members(spec.org, spec.group_name)
-        user_list(result, args.verbose)
+        user_list(result, verbose)
     elif action == 'add_member':
         aserver_api.add_group_member(spec.org, spec.group_name, spec.member)
+        print('Added the user "{spec.member}" to the group "{spec.org}/{spec.group_name}"'.format(spec=spec))
     elif action == 'remove_member':
         aserver_api.remove_group_member(spec.org, spec.group_name, spec.member)
+        print('Removed the user "{spec.member}" from the group "{spec.org}/{spec.group_name}"'.format(spec=spec))
     elif action == 'packages':
         result = aserver_api.group_packages(spec.org, spec.group_name)
-        package_list(result, args.verbose)
+        package_list(result, verbose)
     elif action == 'add_package':
         aserver_api.add_group_package(spec.org, spec.group_name, spec.member)
+        print('Added the package "{spec.member}" to the group "{spec.org}/{spec.group_name}"'.format(spec=spec))
     elif action == 'remove_package':
         aserver_api.remove_group_package(spec.org, spec.group_name, spec.member)
+        print('Removed the package "{spec.member}" from the group "{spec.org}/{spec.group_name}"'.format(spec=spec))
     else:
         raise NotImplementedError(args.action)
 
@@ -53,11 +58,14 @@ def add_parser(subparsers):
                                     help='Manage Groups',
                                     description=__doc__)
 
-    parser.add_argument('action', help='asdf',
-                        choices=['add', 'show', 'members', 'add_member', 'remove_member',
-                                 'packages', 'add_package', 'remove_package'], nargs='?')
-    parser.add_argument('spec', help=group_spec.__doc__, nargs='?', type=group_spec)
-    parser.add_argument('--perms', help='group permissions', choices=['read', 'write', 'admin'], default='read')
-
+    parser.add_argument('action',
+                        choices=['add', 'show', 'members', 'add_member',
+                                 'remove_member', 'packages', 'add_package',
+                                 'remove_package'],
+                        help='The group management command to execute')
+    parser.add_argument('spec', type=group_spec,
+                        help=group_spec.__doc__)
+    parser.add_argument('--perms', choices=['read', 'write', 'admin'], default='read',
+                        help='The permission the group should provide')
 
     parser.set_defaults(main=main)

--- a/binstar_client/commands/groups.py
+++ b/binstar_client/commands/groups.py
@@ -1,13 +1,14 @@
-from binstar_client.utils import get_server_api, parse_specs
 from argparse import FileType, ArgumentError
-from os.path import basename
-import tarfile
 import json
-from warnings import warn
+import logging
+from os.path import basename
 from pprint import pprint
 import re
-from binstar_client.pprintb import package_list, user_list
+import tarfile
+from warnings import warn
 
+from binstar_client.pprintb import package_list, user_list
+from binstar_client.utils import get_server_api, parse_specs
 from binstar_client.utils.spec import group_spec
 
 

--- a/binstar_client/tests/test_groups.py
+++ b/binstar_client/tests/test_groups.py
@@ -1,0 +1,116 @@
+import unittest
+from binstar_client.tests.fixture import CLITestCase
+from binstar_client.tests.urlmock import urlpatch
+from binstar_client.scripts.cli import main
+from binstar_client import errors
+
+
+class Test(CLITestCase):
+    @urlpatch
+    def test_show(self, urls):
+        urls.register(
+            method='GET',
+            path='/groups/org',
+            content='{"groups": [{"name":"grp", "permission": "read"}]}',
+        )
+
+        main(['--show-traceback', 'groups', 'show', 'org'], False)
+
+        urls.assertAllCalled()
+
+    @urlpatch
+    def test_show_group(self, urls):
+        urls.register(
+            method='GET',
+            path='/group/org/owners',
+            content='{"name": "owners", "permission": "read", "members_count": 1, "repos_count": 1}',
+        )
+
+        main(['--show-traceback', 'groups', 'show', 'org/owners'], False)
+
+        urls.assertAllCalled()
+
+    @urlpatch
+    def test_create(self, urls):
+        urls.register(
+            method='POST',
+            path='/group/org/new_grp',
+            status=204,
+        )
+
+        main(['--show-traceback', 'groups', 'add', 'org/new_grp'], False)
+
+        urls.assertAllCalled()
+
+    @urlpatch
+    def test_create_missing_group(self, urls):
+        with self.assertRaisesRegexp(errors.UserError, 'Group name not given'):
+            main(['--show-traceback', 'groups', 'add', 'org'], False)
+
+    @urlpatch
+    def test_add_member(self, urls):
+        urls.register(
+            method='PUT',
+            path='/group/org/grp/members/new_member',
+            status=204,
+        )
+
+        main(['--show-traceback', 'groups', 'add_member', 'org/grp/new_member'], False)
+
+        urls.assertAllCalled()
+
+    @urlpatch
+    def test_add_member_missing_member(self, urls):
+        with self.assertRaisesRegexp(errors.UserError, 'Member name not given'):
+            main(['--show-traceback', 'groups', 'add_member', 'org/grp'], False)
+
+    @urlpatch
+    def test_remove_member(self, urls):
+        urls.register(
+            method='DELETE',
+            path='/group/org/grp/members/new_member',
+            status=204,
+        )
+
+        main(['--show-traceback', 'groups', 'remove_member', 'org/grp/new_member'], False)
+
+        urls.assertAllCalled()
+
+    @urlpatch
+    def test_packages(self, urls):
+        urls.register(
+            method='GET',
+            path='/group/org/grp/packages',
+            content='[{"name": "pkg", "full_name": "org/pkg", "summary": "An org pkg"}]'
+        )
+
+        main(['--show-traceback', 'groups', 'packages', 'org/grp'], False)
+
+        urls.assertAllCalled()
+
+    @urlpatch
+    def test_add_package(self, urls):
+        urls.register(
+            method='PUT',
+            path='/group/org/grp/packages/pkg',
+            status=204,
+        )
+
+        main(['--show-traceback', 'groups', 'add_package', 'org/grp/pkg'], False)
+
+        urls.assertAllCalled()
+
+    @urlpatch
+    def test_remove_package(self, urls):
+        urls.register(
+            method='DELETE',
+            path='/group/org/grp/packages/pkg',
+            status=204,
+        )
+
+        main(['--show-traceback', 'groups', 'remove_package', 'org/grp/pkg'], False)
+
+        urls.assertAllCalled()
+
+if __name__ == "__main__":
+    unittest.main()

--- a/binstar_client/utils/__init__.py
+++ b/binstar_client/utils/__init__.py
@@ -17,8 +17,9 @@ import yaml
 
 from binstar_client.utils.appdirs import AppDirs, EnvAppDirs
 
-from ..errors import UserError
 import warnings
+
+from .spec import PackageSpec, package_specs, parse_specs
 
 
 if 'BINSTAR_CONFIG_DIR' in os.environ:
@@ -43,96 +44,11 @@ except NameError:
 
 log = logging.getLogger('binstar')
 
+
 def jencode(*E, **F):
     payload = dict(*E, **F)
     return json.dumps(payload), {'Content-Type': 'application/json'}
 
-
-class PackageSpec(object):
-    def __init__(self, user, package=None, version=None, basename=None, attrs=None, spec_str=None):
-        self._user = user
-        self._package = package
-        self._version = version
-        self._basename = basename
-        self.attrs = attrs
-        if spec_str:
-            self.spec_str = spec_str
-        else:
-            spec_str = str(user)
-            if package:
-                spec_str = '%s/%s' % (spec_str, package)
-            if version:
-                spec_str = '%s/%s' % (spec_str, version)
-            if basename:
-                spec_str = '%s/%s' % (spec_str, basename)
-            self.spec_str = spec_str
-
-
-
-    def __str__(self):
-        return self.spec_str
-
-    def __repr__(self):
-        return '<PackageSpec %r>' % (self.spec_str)
-
-    @property
-    def user(self):
-        if self._user is None:
-            raise UserError('user not given (got %r expected <username> )' % (self.spec_str,))
-        return self._user
-
-    @property
-    def name(self):
-        if self._package is None:
-            raise UserError('package not given in spec (got %r expected <username>/<package> )' % (self.spec_str,))
-        return self._package
-
-    @property
-    def package(self):
-        if self._package is None:
-            raise UserError('package not given in spec (got %r expected <username>/<package> )' % (self.spec_str,))
-        return self._package
-
-    @property
-    def version(self):
-        if self._version is None:
-            raise UserError('version not given in spec (got %r expected <username>/<package>/<version> )' % (self.spec_str,))
-        return self._version
-
-    @property
-    def basename(self):
-        if self._basename is None:
-            raise UserError('basename not given in spec (got %r expected <username>/<package>/<version>/<filename> )' % (self.spec_str,))
-        return self._basename
-
-def package_specs(spec):
-    user = spec
-    package = None
-    attrs = {}
-    if '/' in user:
-        user, package = user.split('/', 1)
-    if '/' in package:
-        raise TypeError('invalid package spec')
-
-    return PackageSpec(user, package, None, None, attrs, spec)
-
-def parse_specs(spec):
-    user = spec
-    package = version = basename = None
-    attrs = {}
-    if '/' in user:
-        user, package = user.split('/', 1)
-    if package and '/' in package:
-        package, version = package.split('/', 1)
-
-    if version and '/' in version:
-        version, basename = version.split('/', 1)
-
-    if basename and '?' in basename:
-        basename, qsl = basename.rsplit('?', 1)
-        attrs = dict(urlparse.parse_qsl(qsl))
-
-    return PackageSpec(user, package, version, basename, attrs, spec)
 
 def load_token(url):
     tokenfile = join(dirs.user_data_dir, '%s.token' % quote_plus(url))

--- a/binstar_client/utils/spec.py
+++ b/binstar_client/utils/spec.py
@@ -123,7 +123,7 @@ class GroupSpec(object):
     @property
     def member(self):
         if self._member is None:
-            raise UserError('Group name not given (got %r expected <organization>/<group_name>/<member>)' % (self.spec_str,))
+            raise UserError('Member name not given (got %r expected <organization>/<group_name>/<member>)' % (self.spec_str,))
         return self._member
 
 

--- a/binstar_client/utils/spec.py
+++ b/binstar_client/utils/spec.py
@@ -86,3 +86,56 @@ def parse_specs(spec):
         attrs = dict(urlparse.parse_qsl(qsl))
 
     return PackageSpec(user, package, version, basename, attrs, spec)
+
+
+class GroupSpec(object):
+    def __init__(self, org, group_name=None, member=None, spec_str=None):
+        self._org = org
+        self._group_name = group_name
+        self._member = member
+
+        if not spec_str:
+            spec_str = str(org)
+            if group_name:
+                spec_str = '%s/%s' % (spec_str, group_name)
+            if member:
+                spec_str = '%s/%s' % (spec_str, member)
+        self.spec_str = spec_str
+
+    def __str__(self):
+        return self.spec_str
+
+    def __repr__(self):
+        return '<GroupSpec %r>' % (self.spec_str)
+
+    @property
+    def org(self):
+        if self._org is None:
+            raise UserError('Organization not given (got %r expected <organization>)' % (self.spec_str,))
+        return self._org
+
+    @property
+    def group_name(self):
+        if self._group_name is None:
+            raise UserError('Group name not given (got %r expected <organization>/<group_name>)' % (self.spec_str,))
+        return self._group_name
+
+    @property
+    def member(self):
+        if self._member is None:
+            raise UserError('Group name not given (got %r expected <organization>/<group_name>/<member>)' % (self.spec_str,))
+        return self._member
+
+
+def group_spec(spec):
+    '''<organization>/<group_name>/<member>'''
+    org = spec
+    group = member = None
+    if '/' in org:
+        org, group = org.split('/', 1)
+    if group and '/' in group:
+        group, member = group.split('/', 1)
+    if member and '/' in member:
+        raise UserError('Invalid group specification "%s" (unexpected "/" in %s)' % member)
+
+    return GroupSpec(org, group, member, spec)

--- a/binstar_client/utils/spec.py
+++ b/binstar_client/utils/spec.py
@@ -1,0 +1,88 @@
+from binstar_client.errors import UserError
+
+
+class PackageSpec(object):
+    def __init__(self, user, package=None, version=None, basename=None, attrs=None, spec_str=None):
+        self._user = user
+        self._package = package
+        self._version = version
+        self._basename = basename
+        self.attrs = attrs
+        if spec_str:
+            self.spec_str = spec_str
+        else:
+            spec_str = str(user)
+            if package:
+                spec_str = '%s/%s' % (spec_str, package)
+            if version:
+                spec_str = '%s/%s' % (spec_str, version)
+            if basename:
+                spec_str = '%s/%s' % (spec_str, basename)
+            self.spec_str = spec_str
+
+    def __str__(self):
+        return self.spec_str
+
+    def __repr__(self):
+        return '<PackageSpec %r>' % (self.spec_str)
+
+    @property
+    def user(self):
+        if self._user is None:
+            raise UserError('user not given (got %r expected <username> )' % (self.spec_str,))
+        return self._user
+
+    @property
+    def name(self):
+        if self._package is None:
+            raise UserError('package not given in spec (got %r expected <username>/<package> )' % (self.spec_str,))
+        return self._package
+
+    @property
+    def package(self):
+        if self._package is None:
+            raise UserError('package not given in spec (got %r expected <username>/<package> )' % (self.spec_str,))
+        return self._package
+
+    @property
+    def version(self):
+        if self._version is None:
+            raise UserError('version not given in spec (got %r expected <username>/<package>/<version> )' % (self.spec_str,))
+        return self._version
+
+    @property
+    def basename(self):
+        if self._basename is None:
+            raise UserError('basename not given in spec (got %r expected <username>/<package>/<version>/<filename> )' % (self.spec_str,))
+        return self._basename
+
+
+def package_specs(spec):
+    user = spec
+    package = None
+    attrs = {}
+    if '/' in user:
+        user, package = user.split('/', 1)
+    if '/' in package:
+        raise TypeError('invalid package spec')
+
+    return PackageSpec(user, package, None, None, attrs, spec)
+
+
+def parse_specs(spec):
+    user = spec
+    package = version = basename = None
+    attrs = {}
+    if '/' in user:
+        user, package = user.split('/', 1)
+    if package and '/' in package:
+        package, version = package.split('/', 1)
+
+    if version and '/' in version:
+        version, basename = version.split('/', 1)
+
+    if basename and '?' in basename:
+        basename, qsl = basename.rsplit('?', 1)
+        attrs = dict(urlparse.parse_qsl(qsl))
+
+    return PackageSpec(user, package, version, basename, attrs, spec)


### PR DESCRIPTION
Fixes Anaconda-Server/Anaconda-Server#124 #290 

Depends on Anaconda-Server/Anaconda-Server#1959

The `groups` command did not really work properly, and gave terrible error messages. Clean it up a bunch.